### PR TITLE
Add file preview component

### DIFF
--- a/app/company/[id]/view/page.tsx
+++ b/app/company/[id]/view/page.tsx
@@ -2,6 +2,7 @@
 import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import Navbar from '@/components/Navbar';
+import FilePreview from '@/components/FilePreview';
 import { supabase } from '@/lib/supabaseClient';
 import { Company } from '@/types';
 
@@ -63,39 +64,9 @@ export default function CompanyViewPage() {
               </div>
             )}
             {/* Documents preview */}
-            {company.kbis_url && (
-              <div>
-                <strong>KBIS :</strong>
-                <div className="mt-1">
-                  <a href={company.kbis_url} target="_blank" rel="noopener noreferrer" className="text-primary-light underline">
-                    Télécharger le KBIS
-                  </a>
-                  <iframe src={company.kbis_url} className="w-full h-64 mt-2" />
-                </div>
-              </div>
-            )}
-            {company.rib_url && (
-              <div>
-                <strong>RIB :</strong>
-                <div className="mt-1">
-                  <a href={company.rib_url} target="_blank" rel="noopener noreferrer" className="text-primary-light underline">
-                    Télécharger le RIB
-                  </a>
-                  <iframe src={company.rib_url} className="w-full h-64 mt-2" />
-                </div>
-              </div>
-            )}
-            {company.cgv_url && (
-              <div>
-                <strong>CGV :</strong>
-                <div className="mt-1">
-                  <a href={company.cgv_url} target="_blank" rel="noopener noreferrer" className="text-primary-light underline">
-                    Télécharger les CGV
-                  </a>
-                  <iframe src={company.cgv_url} className="w-full h-64 mt-2" />
-                </div>
-              </div>
-            )}
+            {company.kbis_url && <FilePreview url={company.kbis_url} label="KBIS" />}
+            {company.rib_url && <FilePreview url={company.rib_url} label="RIB" />}
+            {company.cgv_url && <FilePreview url={company.cgv_url} label="CGV" />}
           </div>
         )}
       </main>

--- a/app/received/[id]/page.tsx
+++ b/app/received/[id]/page.tsx
@@ -2,6 +2,7 @@
 import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import Navbar from '@/components/Navbar';
+import FilePreview from '@/components/FilePreview';
 import { supabase } from '@/lib/supabaseClient';
 import { Company } from '@/types';
 
@@ -80,38 +81,13 @@ export default function ReceivedDetailPage() {
             )}
             {/* Documents */}
             {isFieldVisible('kbis_url') && company.kbis_url && (
-              <div>
-                <strong>KBIS :</strong>
-                <div className="mt-1">
-                  <a href={company.kbis_url} target="_blank" rel="noopener noreferrer" className="text-primary-light underline">
-                    Télécharger le KBIS
-                  </a>
-                  {/* PDF preview */}
-                  <iframe src={company.kbis_url} className="w-full h-64 mt-2" />
-                </div>
-              </div>
+              <FilePreview url={company.kbis_url} label="KBIS" />
             )}
             {isFieldVisible('rib_url') && company.rib_url && (
-              <div>
-                <strong>RIB :</strong>
-                <div className="mt-1">
-                  <a href={company.rib_url} target="_blank" rel="noopener noreferrer" className="text-primary-light underline">
-                    Télécharger le RIB
-                  </a>
-                  <iframe src={company.rib_url} className="w-full h-64 mt-2" />
-                </div>
-              </div>
+              <FilePreview url={company.rib_url} label="RIB" />
             )}
             {isFieldVisible('cgv_url') && company.cgv_url && (
-              <div>
-                <strong>CGV :</strong>
-                <div className="mt-1">
-                  <a href={company.cgv_url} target="_blank" rel="noopener noreferrer" className="text-primary-light underline">
-                    Télécharger les CGV
-                  </a>
-                  <iframe src={company.cgv_url} className="w-full h-64 mt-2" />
-                </div>
-              </div>
+              <FilePreview url={company.cgv_url} label="CGV" />
             )}
           </div>
         )}

--- a/components/CompanyForm.tsx
+++ b/components/CompanyForm.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react';
 import { supabase } from '@/lib/supabaseClient';
 import { Company } from '@/types';
+import FilePreview from './FilePreview';
 import { useRouter } from 'next/navigation';
 
 interface CompanyFormProps {
@@ -33,9 +34,7 @@ export default function CompanyForm({ company }: CompanyFormProps) {
   const [uploadingRib, setUploadingRib] = useState(false);
   const [uploadingCgv, setUploadingCgv] = useState(false);
   // Option allowing the user to store the uploaded documents with the company
-  const [includeDocs, setIncludeDocs] = useState(
-    Boolean(company?.kbis_url || company?.rib_url || company?.cgv_url)
-  );
+  const [includeDocs, setIncludeDocs] = useState(true);
 
   // Handle uploading of files to Supabase Storage. `field` corresponds to the
   // property name on the company (kbis_url, rib_url, cgv_url).
@@ -374,13 +373,7 @@ export default function CompanyForm({ company }: CompanyFormProps) {
             className="mt-1 block w-full text-sm"
           />
           {uploadingKbis && <p className="text-xs text-neutral-dark">Téléversement en cours…</p>}
-          {values.kbis_url && (
-            <p className="text-xs mt-1">
-              <a href={values.kbis_url} target="_blank" rel="noopener noreferrer" className="text-primary-light underline">
-                KBIS téléversé
-              </a>
-            </p>
-          )}
+          {values.kbis_url && <FilePreview url={values.kbis_url} />}
         </div>
         {/* RIB */}
         <div>
@@ -395,13 +388,7 @@ export default function CompanyForm({ company }: CompanyFormProps) {
             className="mt-1 block w-full text-sm"
           />
           {uploadingRib && <p className="text-xs text-neutral-dark">Téléversement en cours…</p>}
-          {values.rib_url && (
-            <p className="text-xs mt-1">
-              <a href={values.rib_url} target="_blank" rel="noopener noreferrer" className="text-primary-light underline">
-                RIB téléversé
-              </a>
-            </p>
-          )}
+          {values.rib_url && <FilePreview url={values.rib_url} />}
         </div>
         {/* CGV */}
         <div>
@@ -416,13 +403,7 @@ export default function CompanyForm({ company }: CompanyFormProps) {
             className="mt-1 block w-full text-sm"
           />
           {uploadingCgv && <p className="text-xs text-neutral-dark">Téléversement en cours…</p>}
-          {values.cgv_url && (
-            <p className="text-xs mt-1">
-              <a href={values.cgv_url} target="_blank" rel="noopener noreferrer" className="text-primary-light underline">
-                CGV téléversées
-              </a>
-            </p>
-          )}
+          {values.cgv_url && <FilePreview url={values.cgv_url} />}
         </div>
       </div>
       )}

--- a/components/FilePreview.tsx
+++ b/components/FilePreview.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+interface FilePreviewProps {
+  url: string;
+  label?: string;
+}
+
+export default function FilePreview({ url, label }: FilePreviewProps) {
+  const extension = url.split('.').pop()?.toLowerCase();
+
+  if (extension && ['png', 'jpg', 'jpeg', 'gif', 'webp'].includes(extension)) {
+    return (
+      <div className="mt-1">
+        {label && <div className="font-medium">{label}</div>}
+        <img src={url} alt={label ?? 'Fichier'} className="w-full h-auto mt-2" />
+      </div>
+    );
+  }
+
+  if (extension === 'pdf') {
+    return (
+      <div className="mt-1">
+        {label && <div className="font-medium">{label}</div>}
+        <iframe src={url} className="w-full h-64 mt-2" />
+      </div>
+    );
+  }
+
+  // Fallback: just provide a download link
+  return (
+    <div className="mt-1">
+      {label && <div className="font-medium">{label}</div>}
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-primary-light underline"
+      >
+        Télécharger le fichier
+      </a>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable `FilePreview` component able to display images, PDFs or a download link
- show previews inside the company form when uploading documents
- use `FilePreview` for viewing company documents
- enable document fields by default

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc -p tsconfig.json` *(fails to compile due to missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_6888a0ec84c483319c327e549976b81e