### PR TITLE
Add persistent document storage

### DIFF
--- a/app/company/[id]/view/page.tsx
+++ b/app/company/[id]/view/page.tsx
@@ -2,13 +2,15 @@
 import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import Navbar from '@/components/Navbar';
+import FilePreview from '@/components/FilePreview';
 import { supabase } from '@/lib/supabaseClient';
-import { Company } from '@/types';
+import { Company, Document } from '@/types';
 
 export default function CompanyViewPage() {
   const params = useParams();
   const id = params?.id as string;
   const [company, setCompany] = useState<Company | null>(null);
+  const [documents, setDocuments] = useState<Document[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -24,6 +26,11 @@ export default function CompanyViewPage() {
         setError(error.message);
       } else if (data) {
         setCompany(data as Company);
+        const { data: docs } = await supabase
+          .from('documents')
+          .select('*')
+          .eq('company_id', id);
+        setDocuments(docs as Document[] || []);
       }
       setLoading(false);
     };
@@ -63,39 +70,12 @@ export default function CompanyViewPage() {
               </div>
             )}
             {/* Documents preview */}
-            {company.kbis_url && (
-              <div>
-                <strong>KBIS :</strong>
-                <div className="mt-1">
-                  <a href={company.kbis_url} target="_blank" rel="noopener noreferrer" className="text-primary-light underline">
-                    Télécharger le KBIS
-                  </a>
-                  <iframe src={company.kbis_url} className="w-full h-64 mt-2" />
-                </div>
-              </div>
-            )}
-            {company.rib_url && (
-              <div>
-                <strong>RIB :</strong>
-                <div className="mt-1">
-                  <a href={company.rib_url} target="_blank" rel="noopener noreferrer" className="text-primary-light underline">
-                    Télécharger le RIB
-                  </a>
-                  <iframe src={company.rib_url} className="w-full h-64 mt-2" />
-                </div>
-              </div>
-            )}
-            {company.cgv_url && (
-              <div>
-                <strong>CGV :</strong>
-                <div className="mt-1">
-                  <a href={company.cgv_url} target="_blank" rel="noopener noreferrer" className="text-primary-light underline">
-                    Télécharger les CGV
-                  </a>
-                  <iframe src={company.cgv_url} className="w-full h-64 mt-2" />
-                </div>
-              </div>
-            )}
+            {company.kbis_url && <FilePreview url={company.kbis_url} label="KBIS" />}
+            {company.rib_url && <FilePreview url={company.rib_url} label="RIB" />}
+            {company.cgv_url && <FilePreview url={company.cgv_url} label="CGV" />}
+            {documents.map((doc) => (
+              <FilePreview key={doc.id} url={doc.url} label={doc.name} />
+            ))}
           </div>
         )}
       </main>

--- a/app/received/[id]/page.tsx
+++ b/app/received/[id]/page.tsx
@@ -2,14 +2,16 @@
 import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import Navbar from '@/components/Navbar';
+import FilePreview from '@/components/FilePreview';
 import { supabase } from '@/lib/supabaseClient';
-import { Company } from '@/types';
+import { Company, Document } from '@/types';
 
 export default function ReceivedDetailPage() {
   const params = useParams();
   const shareId = params?.id as string;
   const [company, setCompany] = useState<Company | null>(null);
   const [fields, setFields] = useState<string[] | null>(null);
+  const [documents, setDocuments] = useState<Document[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -26,6 +28,11 @@ export default function ReceivedDetailPage() {
       } else if (data) {
         setFields(data.shared_fields as any);
         setCompany(data.company as Company);
+        const { data: docs } = await supabase
+          .from('documents')
+          .select('*')
+          .eq('company_id', data.company.id);
+        setDocuments(docs as Document[] || []);
       }
       setLoading(false);
     };
@@ -80,39 +87,17 @@ export default function ReceivedDetailPage() {
             )}
             {/* Documents */}
             {isFieldVisible('kbis_url') && company.kbis_url && (
-              <div>
-                <strong>KBIS :</strong>
-                <div className="mt-1">
-                  <a href={company.kbis_url} target="_blank" rel="noopener noreferrer" className="text-primary-light underline">
-                    Télécharger le KBIS
-                  </a>
-                  {/* PDF preview */}
-                  <iframe src={company.kbis_url} className="w-full h-64 mt-2" />
-                </div>
-              </div>
+              <FilePreview url={company.kbis_url} label="KBIS" />
             )}
             {isFieldVisible('rib_url') && company.rib_url && (
-              <div>
-                <strong>RIB :</strong>
-                <div className="mt-1">
-                  <a href={company.rib_url} target="_blank" rel="noopener noreferrer" className="text-primary-light underline">
-                    Télécharger le RIB
-                  </a>
-                  <iframe src={company.rib_url} className="w-full h-64 mt-2" />
-                </div>
-              </div>
+              <FilePreview url={company.rib_url} label="RIB" />
             )}
             {isFieldVisible('cgv_url') && company.cgv_url && (
-              <div>
-                <strong>CGV :</strong>
-                <div className="mt-1">
-                  <a href={company.cgv_url} target="_blank" rel="noopener noreferrer" className="text-primary-light underline">
-                    Télécharger les CGV
-                  </a>
-                  <iframe src={company.cgv_url} className="w-full h-64 mt-2" />
-                </div>
-              </div>
+              <FilePreview url={company.cgv_url} label="CGV" />
             )}
+            {documents.map((doc) => (
+              <FilePreview key={doc.id} url={doc.url} label={doc.name} />
+            ))}
           </div>
         )}
       </main>

--- a/components/CompanyForm.tsx
+++ b/components/CompanyForm.tsx
@@ -1,7 +1,8 @@
 "use client";
 import { useState } from 'react';
 import { supabase } from '@/lib/supabaseClient';
-import { Company } from '@/types';
+import { Company, Document } from '@/types';
+import FilePreview from './FilePreview';
 import { useRouter } from 'next/navigation';
 
 interface CompanyFormProps {
@@ -33,9 +34,24 @@ export default function CompanyForm({ company }: CompanyFormProps) {
   const [uploadingRib, setUploadingRib] = useState(false);
   const [uploadingCgv, setUploadingCgv] = useState(false);
   // Option allowing the user to store the uploaded documents with the company
-  const [includeDocs, setIncludeDocs] = useState(
-    Boolean(company?.kbis_url || company?.rib_url || company?.cgv_url)
-  );
+  const [includeDocs, setIncludeDocs] = useState(true);
+
+  const saveDocuments = async (companyId: string) => {
+    const docs = [
+      { url: values.kbis_url, type: 'kbis', name: 'KBIS' },
+      { url: values.rib_url, type: 'rib', name: 'RIB' },
+      { url: values.cgv_url, type: 'cgv', name: 'CGV' },
+    ].filter((d) => d.url);
+    for (const doc of docs) {
+      const { error } = await supabase
+        .from('documents')
+        .upsert(
+          { company_id: companyId, name: doc.name, type: doc.type, url: doc.url },
+          { onConflict: 'company_id,type' }
+        );
+      if (error) throw error;
+    }
+  };
 
   // Handle uploading of files to Supabase Storage. `field` corresponds to the
   // property name on the company (kbis_url, rib_url, cgv_url).
@@ -138,6 +154,7 @@ export default function CompanyForm({ company }: CompanyFormProps) {
           .update({ ...payload, updated_at: new Date().toISOString() })
           .eq('id', company.id);
         if (error) throw error;
+        if (includeDocs) await saveDocuments(company.id);
       } else {
         // Insert new company
         const {
@@ -150,13 +167,18 @@ export default function CompanyForm({ company }: CompanyFormProps) {
         if (!user) {
           throw new Error("Vous devez être connecté pour créer une fiche.");
         }
-        const { error } = await supabase.from('companies').insert({
-          ...payload,
-          user_id: user.id,
-          created_at: new Date().toISOString(),
-          updated_at: new Date().toISOString(),
-        });
+        const { data: inserted, error } = await supabase
+          .from('companies')
+          .insert({
+            ...payload,
+            user_id: user.id,
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          })
+          .select('id')
+          .single();
         if (error) throw error;
+        if (includeDocs && inserted) await saveDocuments(inserted.id);
       }
       // Après création ou mise à jour, redirige vers le tableau de bord et force un rafraîchissement.
       router.replace('/dashboard');
@@ -374,13 +396,7 @@ export default function CompanyForm({ company }: CompanyFormProps) {
             className="mt-1 block w-full text-sm"
           />
           {uploadingKbis && <p className="text-xs text-neutral-dark">Téléversement en cours…</p>}
-          {values.kbis_url && (
-            <p className="text-xs mt-1">
-              <a href={values.kbis_url} target="_blank" rel="noopener noreferrer" className="text-primary-light underline">
-                KBIS téléversé
-              </a>
-            </p>
-          )}
+          {values.kbis_url && <FilePreview url={values.kbis_url} />}
         </div>
         {/* RIB */}
         <div>
@@ -395,13 +411,7 @@ export default function CompanyForm({ company }: CompanyFormProps) {
             className="mt-1 block w-full text-sm"
           />
           {uploadingRib && <p className="text-xs text-neutral-dark">Téléversement en cours…</p>}
-          {values.rib_url && (
-            <p className="text-xs mt-1">
-              <a href={values.rib_url} target="_blank" rel="noopener noreferrer" className="text-primary-light underline">
-                RIB téléversé
-              </a>
-            </p>
-          )}
+          {values.rib_url && <FilePreview url={values.rib_url} />}
         </div>
         {/* CGV */}
         <div>
@@ -416,13 +426,7 @@ export default function CompanyForm({ company }: CompanyFormProps) {
             className="mt-1 block w-full text-sm"
           />
           {uploadingCgv && <p className="text-xs text-neutral-dark">Téléversement en cours…</p>}
-          {values.cgv_url && (
-            <p className="text-xs mt-1">
-              <a href={values.cgv_url} target="_blank" rel="noopener noreferrer" className="text-primary-light underline">
-                CGV téléversées
-              </a>
-            </p>
-          )}
+          {values.cgv_url && <FilePreview url={values.cgv_url} />}
         </div>
       </div>
       )}

--- a/components/FilePreview.tsx
+++ b/components/FilePreview.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+interface FilePreviewProps {
+  url: string;
+  label?: string;
+}
+
+export default function FilePreview({ url, label }: FilePreviewProps) {
+  const extension = url.split('.').pop()?.toLowerCase();
+
+  if (extension && ['png', 'jpg', 'jpeg', 'gif', 'webp'].includes(extension)) {
+    return (
+      <div className="mt-1">
+        {label && <div className="font-medium">{label}</div>}
+        <img src={url} alt={label ?? 'Fichier'} className="w-full h-auto mt-2" />
+      </div>
+    );
+  }
+
+  if (extension === 'pdf') {
+    return (
+      <div className="mt-1">
+        {label && <div className="font-medium">{label}</div>}
+        <iframe src={url} className="w-full h-64 mt-2" />
+      </div>
+    );
+  }
+
+  // Fallback: just provide a download link
+  return (
+    <div className="mt-1">
+      {label && <div className="font-medium">{label}</div>}
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-primary-light underline"
+      >
+        Télécharger le fichier
+      </a>
+    </div>
+  );
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -37,3 +37,12 @@ export interface Share {
   accepted: boolean;
   created_at: string;
 }
+
+export interface Document {
+  id: string;
+  company_id: string;
+  name: string;
+  type: string;
+  url: string;
+  created_at: string;
+}


### PR DESCRIPTION
## Summary
- introduce `documents` table in `schema.sql`
- update types with new `Document` interface
- store uploaded files in `documents` via `CompanyForm`
- fetch and display documents on company view and received pages
- add generic `FilePreview` component
- fix missing newline in `types/index.ts`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc -p tsconfig.json` *(fails: modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_6888a0ec84c483319c327e549976b81e