### PR TITLE
Update document RLS policy

### DIFF
--- a/app/company/[id]/view/page.tsx
+++ b/app/company/[id]/view/page.tsx
@@ -2,13 +2,15 @@
 import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import Navbar from '@/components/Navbar';
+import FilePreview from '@/components/FilePreview';
 import { supabase } from '@/lib/supabaseClient';
-import { Company } from '@/types';
+import { Company, Document } from '@/types';
 
 export default function CompanyViewPage() {
   const params = useParams();
   const id = params?.id as string;
   const [company, setCompany] = useState<Company | null>(null);
+  const [documents, setDocuments] = useState<Document[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -24,6 +26,11 @@ export default function CompanyViewPage() {
         setError(error.message);
       } else if (data) {
         setCompany(data as Company);
+        const { data: docs } = await supabase
+          .from('documents')
+          .select('*')
+          .eq('company_id', id);
+        setDocuments(docs as Document[] || []);
       }
       setLoading(false);
     };
@@ -63,39 +70,12 @@ export default function CompanyViewPage() {
               </div>
             )}
             {/* Documents preview */}
-            {company.kbis_url && (
-              <div>
-                <strong>KBIS :</strong>
-                <div className="mt-1">
-                  <a href={company.kbis_url} target="_blank" rel="noopener noreferrer" className="text-primary-light underline">
-                    Télécharger le KBIS
-                  </a>
-                  <iframe src={company.kbis_url} className="w-full h-64 mt-2" />
-                </div>
-              </div>
-            )}
-            {company.rib_url && (
-              <div>
-                <strong>RIB :</strong>
-                <div className="mt-1">
-                  <a href={company.rib_url} target="_blank" rel="noopener noreferrer" className="text-primary-light underline">
-                    Télécharger le RIB
-                  </a>
-                  <iframe src={company.rib_url} className="w-full h-64 mt-2" />
-                </div>
-              </div>
-            )}
-            {company.cgv_url && (
-              <div>
-                <strong>CGV :</strong>
-                <div className="mt-1">
-                  <a href={company.cgv_url} target="_blank" rel="noopener noreferrer" className="text-primary-light underline">
-                    Télécharger les CGV
-                  </a>
-                  <iframe src={company.cgv_url} className="w-full h-64 mt-2" />
-                </div>
-              </div>
-            )}
+            {company.kbis_url && <FilePreview url={company.kbis_url} label="KBIS" />}
+            {company.rib_url && <FilePreview url={company.rib_url} label="RIB" />}
+            {company.cgv_url && <FilePreview url={company.cgv_url} label="CGV" />}
+            {documents.map((doc) => (
+              <FilePreview key={doc.id} url={doc.url} label={doc.name} />
+            ))}
           </div>
         )}
       </main>

--- a/app/received/[id]/page.tsx
+++ b/app/received/[id]/page.tsx
@@ -2,14 +2,16 @@
 import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import Navbar from '@/components/Navbar';
+import FilePreview from '@/components/FilePreview';
 import { supabase } from '@/lib/supabaseClient';
-import { Company } from '@/types';
+import { Company, Document } from '@/types';
 
 export default function ReceivedDetailPage() {
   const params = useParams();
   const shareId = params?.id as string;
   const [company, setCompany] = useState<Company | null>(null);
   const [fields, setFields] = useState<string[] | null>(null);
+  const [documents, setDocuments] = useState<Document[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -26,6 +28,11 @@ export default function ReceivedDetailPage() {
       } else if (data) {
         setFields(data.shared_fields as any);
         setCompany(data.company as Company);
+        const { data: docs } = await supabase
+          .from('documents')
+          .select('*')
+          .eq('company_id', data.company.id);
+        setDocuments(docs as Document[] || []);
       }
       setLoading(false);
     };
@@ -80,39 +87,17 @@ export default function ReceivedDetailPage() {
             )}
             {/* Documents */}
             {isFieldVisible('kbis_url') && company.kbis_url && (
-              <div>
-                <strong>KBIS :</strong>
-                <div className="mt-1">
-                  <a href={company.kbis_url} target="_blank" rel="noopener noreferrer" className="text-primary-light underline">
-                    Télécharger le KBIS
-                  </a>
-                  {/* PDF preview */}
-                  <iframe src={company.kbis_url} className="w-full h-64 mt-2" />
-                </div>
-              </div>
+              <FilePreview url={company.kbis_url} label="KBIS" />
             )}
             {isFieldVisible('rib_url') && company.rib_url && (
-              <div>
-                <strong>RIB :</strong>
-                <div className="mt-1">
-                  <a href={company.rib_url} target="_blank" rel="noopener noreferrer" className="text-primary-light underline">
-                    Télécharger le RIB
-                  </a>
-                  <iframe src={company.rib_url} className="w-full h-64 mt-2" />
-                </div>
-              </div>
+              <FilePreview url={company.rib_url} label="RIB" />
             )}
             {isFieldVisible('cgv_url') && company.cgv_url && (
-              <div>
-                <strong>CGV :</strong>
-                <div className="mt-1">
-                  <a href={company.cgv_url} target="_blank" rel="noopener noreferrer" className="text-primary-light underline">
-                    Télécharger les CGV
-                  </a>
-                  <iframe src={company.cgv_url} className="w-full h-64 mt-2" />
-                </div>
-              </div>
+              <FilePreview url={company.cgv_url} label="CGV" />
             )}
+            {documents.map((doc) => (
+              <FilePreview key={doc.id} url={doc.url} label={doc.name} />
+            ))}
           </div>
         )}
       </main>

--- a/components/FilePreview.tsx
+++ b/components/FilePreview.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+interface FilePreviewProps {
+  url: string;
+  label?: string;
+}
+
+export default function FilePreview({ url, label }: FilePreviewProps) {
+  const extension = url.split('.').pop()?.toLowerCase();
+
+  if (extension && ['png', 'jpg', 'jpeg', 'gif', 'webp'].includes(extension)) {
+    return (
+      <div className="mt-1">
+        {label && <div className="font-medium">{label}</div>}
+        <img src={url} alt={label ?? 'Fichier'} className="w-full h-auto mt-2" />
+      </div>
+    );
+  }
+
+  if (extension === 'pdf') {
+    return (
+      <div className="mt-1">
+        {label && <div className="font-medium">{label}</div>}
+        <iframe src={url} className="w-full h-64 mt-2" />
+      </div>
+    );
+  }
+
+  // Fallback: just provide a download link
+  return (
+    <div className="mt-1">
+      {label && <div className="font-medium">{label}</div>}
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-primary-light underline"
+      >
+        Télécharger le fichier
+      </a>
+    </div>
+  );
+}

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -102,3 +102,43 @@ create index if not exists idx_companies_user on public.companies (user_id);
 create index if not exists idx_shares_recipient on public.shares (recipient_user_id);
 create index if not exists idx_invites_invitee_user on public.invites (invitee_user_id);
 create index if not exists idx_invites_invitee_email on public.invites (invitee_email);
+
+-- Table storing documents uploaded by companies
+create table if not exists public.documents (
+  id uuid default uuid_generate_v4() primary key,
+  company_id uuid references public.companies (id) on delete cascade,
+  name text not null,
+  type text not null,
+  url text not null,
+  created_at timestamp with time zone default now()
+);
+
+-- Index for quick lookups by company
+create index if not exists idx_documents_company on public.documents (company_id);
+
+alter table public.documents enable row level security;
+
+drop policy if exists "documents_select_company" on public.documents;
+create policy "documents_select_company" on public.documents
+  for select
+  using (
+    -- Owner of the company
+    exists (
+      select 1 from public.companies
+      where id = company_id and user_id = auth.uid()
+    )
+    -- Or recipient of an accepted share
+    or exists (
+      select 1 from public.shares
+      where company_id = documents.company_id
+        and recipient_user_id = auth.uid()
+        and accepted
+    )
+  );
+
+drop policy if exists "documents_insert_company" on public.documents;
+create policy "documents_insert_company" on public.documents
+  for insert
+  with check (
+    exists (select 1 from public.companies where id = company_id and user_id = auth.uid())
+  );

--- a/types/index.ts
+++ b/types/index.ts
@@ -37,3 +37,12 @@ export interface Share {
   accepted: boolean;
   created_at: string;
 }
+
+export interface Document {
+  id: string;
+  company_id: string;
+  name: string;
+  type: string;
+  url: string;
+  created_at: string;
+}


### PR DESCRIPTION
## Summary
- allow share recipients to read company documents in `schema.sql`
- add index for quick document queries

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc -p tsconfig.json` *(fails: modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_6888a0ec84c483319c327e549976b81e